### PR TITLE
Fix issue with global nunjucks configuration.

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ var fs = require('fs');
 var crypto = require('crypto');
 var nunjucks = require('nunjucks');
 
-nunjucks.configure(__dirname);
+var nj = nunjucks.configure(__dirname);
 
 var keyGenerator = function() {};
 
@@ -29,7 +29,7 @@ keyGenerator.register = function(handlers, app, config) {
         var publicHex = publicHash.digest('hex');
         var secretHash = crypto.createHash('sha1').update(publicHex + (config.logKey || 'acos'));
         var secretHex = secretHash.digest('hex');
-        var result = nunjucks.render('template.html', {
+        var result = nj.render('template.html', {
           publicKey: publicHex,
           secretKey: secretHex,
           host: config.serverAddress


### PR DESCRIPTION
The global nunjucks configuration is overridden any time some other app uses it. This app may then crash because the template is not found. The solution is to use the nunjucks environment that remembers the template directory that is set in the beginning.